### PR TITLE
TT Cutoffs + PVS

### DIFF
--- a/Logic/Data/Enums.cs
+++ b/Logic/Data/Enums.cs
@@ -127,6 +127,14 @@ namespace Peeper.Logic.Data
         Exact = Beta | Alpha
     };
 
+    public static class Bound
+    {
+        public const int BoundNone = (int)TTNodeType.Invalid;
+        public const int BoundUpper = (int)TTNodeType.Beta;
+        public const int BoundLower = (int)TTNodeType.Alpha;
+        public const int BoundExact = (int)TTNodeType.Exact;
+    }
+
     public static class Squares
     {
         public const int I9 = 0;

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -87,6 +87,14 @@ namespace Peeper.Logic.Search
             short ttScore = ss->TTHit ? MakeNormalScore(tte->Score, ss->Ply) : ScoreNone;
             Move ttMove = isRoot ? thisThread.CurrentMove : (ss->TTHit ? tte->BestMove : Move.Null);
 
+            if (!isPV
+                && tte->Depth >= depth
+                && ttScore != ScoreNone
+                && tte->IsScoreUsable(ttScore, beta))
+            {
+                return ttScore;
+            }
+
             if (ss->InCheck)
             {
                 //  If we are in check, don't bother getting a static evaluation or pruning.

--- a/Logic/Transposition/TTEntry.cs
+++ b/Logic/Transposition/TTEntry.cs
@@ -45,6 +45,9 @@ namespace Peeper.Logic.Transposition
         public readonly sbyte RelAge(byte age) => (sbyte)((TT_AGE_CYCLE + age - _AgePVType) & TT_AGE_MASK);
         public readonly bool IsEmpty => _Depth == 0;
 
+        [MethodImpl(Inline)]
+        public readonly bool IsScoreUsable(int score, int bound) => (Bound & (score >= bound ? BoundLower : BoundUpper)) != 0;
+
         public void Update(ulong key, short score, TTNodeType nodeType, int depth, Move move, short statEval, byte age, bool isPV = false)
         {
             var k = (ushort)key;

--- a/Logic/Util/GlobalUsings.cs
+++ b/Logic/Util/GlobalUsings.cs
@@ -5,6 +5,7 @@ global using Peeper.Logic.Core;
 global using Peeper.Logic.Data;
 global using Peeper.Logic.Util;
 
+global using static Peeper.Logic.Data.Bound;
 global using static Peeper.Logic.Data.Color;
 global using static Peeper.Logic.Data.Piece;
 global using static Peeper.Logic.Data.Ranks;


### PR DESCRIPTION
PVS:
```
Elo   | 24.68 +- 9.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 4780 W: 2545 L: 2206 D: 29
Penta | [449, 11, 1297, 18, 615]
```
https://somelizard.pythonanywhere.com/test/2345/

TT:
```
Elo   | 47.97 +- 17.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1618 W: 918 L: 696 D: 4
Penta | [158, 3, 377, 1, 270]
```
https://somelizard.pythonanywhere.com/test/2347/