### PR TITLE
Basic RFP + depth 8 bench

### DIFF
--- a/Logic/Search/SearchConstants.cs
+++ b/Logic/Search/SearchConstants.cs
@@ -44,5 +44,14 @@ namespace Peeper.Logic.Search
         {
             return Math.Abs(Math.Abs(score) - ScoreMate) < MaxDepth;
         }
+
+        [MethodImpl(Inline)]
+        public static bool IsWin(int score) => score >= ScoreTTWin;
+        
+        [MethodImpl(Inline)]
+        public static bool IsLoss(int score) => score <= ScoreTTLoss;
+        
+        [MethodImpl(Inline)]
+        public static bool IsDecisive(int score) => IsWin(score) || IsLoss(score);
     }
 }

--- a/Logic/Search/SearchOptions.cs
+++ b/Logic/Search/SearchOptions.cs
@@ -14,5 +14,8 @@ namespace Peeper.Logic.Search
         public static bool CuteChessWorkaround = false;
 
         public static int AspWindow = 0;
+
+        public static int RFPMult = 100;
+        public static int RFPDepth = 5;
     }
 }

--- a/Logic/USI/USIClient.cs
+++ b/Logic/USI/USIClient.cs
@@ -268,7 +268,12 @@ namespace Peeper.Logic.USI
             Options[nameof(Hash)].SetMinMax(1, 1048576);
 
             Options[nameof(MoveOverhead)].SetMinMax(0, 2000);
+
             Options[nameof(AspWindow)].SetMinMax(0, 30);
+
+            Options[nameof(RFPDepth)].SetMinMax(1, 10);
+            Options[nameof(RFPMult)].SetMinMax(50, 140);
+
 
             foreach (var optName in Options.Keys)
             {

--- a/Logic/Util/SearchBench.cs
+++ b/Logic/Util/SearchBench.cs
@@ -5,7 +5,7 @@ namespace Peeper.Logic.Util
 {
     public static class SearchBench
     {
-        public const int DefaultDepth = 4;
+        public const int DefaultDepth = 8;
 
         public static void Go(int depth = DefaultDepth, bool openBench = false)
         {


### PR DESCRIPTION
```
Elo   | 139.45 +- 30.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 5.00]
Games | N: 572 W: 387 L: 169 D: 16
Penta | [23, 4, 120, 10, 129]
```
https://somelizard.pythonanywhere.com/test/2356/