### PR TITLE
Basic SEE cutoffs

### DIFF
--- a/Logic/Core/Bitboard.cs
+++ b/Logic/Core/Bitboard.cs
@@ -174,5 +174,19 @@ namespace Peeper.Logic.Core
         {
             return ActiveFormatter.DisplayBoard(this);
         }
+
+        [MethodImpl(Inline)] public Bitmask PieceMask(int a, int b, int c, int d, int e, int f, int g, int h, int i) => PieceMask(a, b, c, d, e, f, g, h) | Pieces[i];
+        [MethodImpl(Inline)] public Bitmask PieceMask(int a, int b, int c, int d, int e, int f, int g, int h) => PieceMask(a, b, c, d, e, f, g) | Pieces[h];
+        [MethodImpl(Inline)] public Bitmask PieceMask(int a, int b, int c, int d, int e, int f, int g) => PieceMask(a, b, c, d, e, f) | Pieces[g];
+        [MethodImpl(Inline)] public Bitmask PieceMask(int a, int b, int c, int d, int e, int f) => PieceMask(a, b, c, d, e) | Pieces[f];
+        [MethodImpl(Inline)] public Bitmask PieceMask(int a, int b, int c, int d, int e) => PieceMask(a, b, c, d) | Pieces[e];
+        [MethodImpl(Inline)] public Bitmask PieceMask(int a, int b, int c, int d) => PieceMask(a, b, c) | Pieces[d];
+        [MethodImpl(Inline)] public Bitmask PieceMask(int a, int b, int c) => PieceMask(a, b) | Pieces[c];
+        [MethodImpl(Inline)] public Bitmask PieceMask(int a, int b) => PieceMask(a) | Pieces[b];
+        [MethodImpl(Inline)] public Bitmask PieceMask(int a) => Pieces[a];
+
+        [MethodImpl(Inline)] public Bitmask Golds() => PieceMask(PawnPromoted, LancePromoted, KnightPromoted, SilverPromoted, Gold);
+        [MethodImpl(Inline)] public Bitmask Bishops() => PieceMask(Bishop, BishopPromoted);
+        [MethodImpl(Inline)] public Bitmask Rooks() => PieceMask(Rook, RookPromoted);
     }
 }

--- a/Logic/Evaluation/MaterialCounting.cs
+++ b/Logic/Evaluation/MaterialCounting.cs
@@ -3,19 +3,19 @@ namespace Peeper.Logic.Evaluation
 {
     public static unsafe class MaterialCounting
     {
-        private const int ValuePawn           = 100;
-        private const int ValuePawnPromoted   = 350;
-        private const int ValueLance          = 400;
-        private const int ValueKnight         = 500;
-        private const int ValueLancePromoted  = 790;
-        private const int ValueKnightPromoted = 790;
-        private const int ValueSilver         = 700;
-        private const int ValueSilverPromoted = 790;
-        private const int ValueGold           = 800;
-        private const int ValueBishop         = 1100;
-        private const int ValueRook           = 1300;
-        private const int ValueBishopPromoted = 1500;
-        private const int ValueRookPromoted   = 1700;
+        public const int ValuePawn           = 100;
+        public const int ValuePawnPromoted   = 350;
+        public const int ValueLance          = 400;
+        public const int ValueKnight         = 500;
+        public const int ValueLancePromoted  = 790;
+        public const int ValueKnightPromoted = 790;
+        public const int ValueSilver         = 700;
+        public const int ValueSilverPromoted = 790;
+        public const int ValueGold           = 800;
+        public const int ValueBishop         = 1100;
+        public const int ValueRook           = 1300;
+        public const int ValueBishopPromoted = 1500;
+        public const int ValueRookPromoted   = 1700;
 
         //  PieceValue plus a small amount for normal pieces,
         //  and the value of the piece itself + the promoted value for captured promoted pieces.

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -453,7 +453,8 @@ namespace Peeper.Logic.Search
             if (swap <= 0)
                 return true;
 
-            var occ = (bb.Occupancy ^ SquareBB(moveFrom)) | SquareBB(moveTo);
+            var fromMask = m.IsDrop ? 0 : SquareBB(moveFrom);
+            var occ = (bb.Occupancy ^ fromMask) | SquareBB(moveTo);
 
             var attackers = bb.AttackersTo(moveTo, occ);
             Bitmask stmAttackers;

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -9,6 +9,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Xml.Linq;
 
+using static Peeper.Logic.Evaluation.MaterialCounting;
 using static Peeper.Logic.Transposition.TTEntry;
 
 namespace Peeper.Logic.Search
@@ -375,6 +376,12 @@ namespace Peeper.Logic.Search
 
                 var (moveFrom, moveTo) = m.Unpack();
 
+                if (!IsLoss(bestScore))
+                {
+                    if (!SEE_GE(pos, m, -200))
+                        continue;
+                }
+
                 ss->CurrentMove = m;
                 ss->ContinuationHistory = history.Continuations[0][0][0, 0, 0];
 
@@ -429,6 +436,123 @@ namespace Peeper.Logic.Search
         {
             return score;
         }
+
+
+        private static bool SEE_GE(Position pos, Move m, int threshold = 1)
+        {
+            ref Bitboard bb = ref pos.bb;
+
+            var (moveFrom, moveTo) = m.Unpack();
+
+            int swap = MaterialCounting.GetPieceValue(bb.GetPieceAtIndex(moveTo)) - threshold;
+            if (swap < 0)
+                return false;
+
+            var movedPiece = pos.MovedPiece(m);
+            swap = MaterialCounting.GetPieceValue(movedPiece) - swap;
+            if (swap <= 0)
+                return true;
+
+            var occ = (bb.Occupancy ^ SquareBB(moveFrom)) | SquareBB(moveTo);
+
+            var attackers = bb.AttackersTo(moveTo, occ);
+            Bitmask stmAttackers;
+            Bitmask temp;
+
+            int stm = pos.ToMove;
+            int res = 1;
+            while (true)
+            {
+                stm = Not(stm);
+                attackers &= occ;
+
+                stmAttackers = attackers & bb.Colors[stm];
+                if (stmAttackers == 0)
+                {
+                    break;
+                }
+
+                if ((pos.State->Pinners[Not(stm)] & occ) != 0)
+                {
+                    stmAttackers &= ~pos.State->BlockingPieces[stm];
+                    if (stmAttackers == 0)
+                    {
+                        break;
+                    }
+                }
+
+                res ^= 1;
+
+                if ((temp = stmAttackers & bb.Pieces[Pawn]) != 0)
+                {
+                    if ((swap = ValuePawn - swap) < res)
+                        break;
+                }
+                else if ((temp = stmAttackers & bb.Pieces[Lance]) != 0)
+                {
+                    if ((swap = ValueLance - swap) < res)
+                        break;
+                }
+                else if ((temp = stmAttackers & bb.Pieces[Knight]) != 0)
+                {
+                    if ((swap = ValueKnight - swap) < res)
+                        break;
+                    occ ^= SquareBB(LSB(temp));
+
+                    continue;
+                }
+                else if ((temp = stmAttackers & bb.Pieces[Silver]) != 0)
+                {
+                    if ((swap = ValueSilver - swap) < res)
+                        break;
+                }
+                else if ((temp = stmAttackers & bb.Golds()) != 0)
+                {
+                    if ((swap = ValueGold - swap) < res)
+                        break;
+                }
+                else if ((temp = stmAttackers & bb.Pieces[Bishop]) != 0)
+                {
+                    if ((swap = ValueBishop - swap) < res)
+                        break;
+                }
+                else if ((temp = stmAttackers & bb.Pieces[Rook]) != 0)
+                {
+                    if ((swap = ValueRook - swap) < res)
+                        break;
+                }
+                else if ((temp = stmAttackers & bb.Pieces[BishopPromoted]) != 0)
+                {
+                    if ((swap = ValueBishopPromoted - swap) < res)
+                        break;
+                }
+                else if ((temp = stmAttackers & bb.Pieces[RookPromoted]) != 0)
+                {
+                    if ((swap = ValueRookPromoted - swap) < res)
+                        break;
+                }
+                else
+                {
+                    if ((attackers & ~bb.Pieces[stm]) != 0)
+                    {
+                        return (res ^ 1) != 0;
+                    }
+                    else
+                    {
+                        return res != 0;
+                    }
+                }
+
+                int sq = PopLSB(&temp);
+                occ ^= SquareBB(sq);
+
+                attackers |= GetBishopMoves(moveTo, occ) & bb.Bishops();
+                attackers |= GetRookMoves(moveTo, occ) & bb.Rooks();
+            }
+
+            return res != 0;
+        }
+
 
         private static int RFPMargin(int depth)
         {


### PR DESCRIPTION
```
Elo   | 83.86 +- 22.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 5.00]
Games | N: 832 W: 492 L: 295 D: 45
Penta | [39, 19, 199, 24, 135]
```
https://somelizard.pythonanywhere.com/test/2377/