### PR TITLE
TT clusters

### DIFF
--- a/Logic/Transposition/TTCluster.cs
+++ b/Logic/Transposition/TTCluster.cs
@@ -12,23 +12,19 @@ namespace Peeper.Logic.Transposition
     public unsafe struct TTCluster
     {
         [FieldOffset( 0)] private TTEntry _elem0;
-#if NO
         [FieldOffset(10)] private TTEntry _elem1;
         [FieldOffset(20)] private TTEntry _elem2;
         [FieldOffset(30)] private fixed byte _pad0[2];
-#endif
 
 
         public TTCluster()
         {
             _elem0 = new TTEntry();
-#if NO
             _elem1 = new TTEntry();
             _elem2 = new TTEntry();
 
             _pad0[0] = (byte)':';
-            _pad0[1] = (byte)')';
-#endif
+            _pad0[1] = (byte)'3';
         }
 
         /// <summary>

--- a/Logic/Transposition/TTEntry.cs
+++ b/Logic/Transposition/TTEntry.cs
@@ -15,18 +15,18 @@ namespace Peeper.Logic.Transposition
     /// <para></para>
     /// The replacement strategy and depth logic are inspired by Stockfish and Berserk.
     /// </summary>
-    [StructLayout(LayoutKind.Explicit, Pack = 2, Size = 12)]
+    [StructLayout(LayoutKind.Explicit, Pack = 2, Size = 10)]
     public struct TTEntry
     {
         public const int DepthOffset = -7;
         public const int DepthNone = -6;
 
-        [FieldOffset( 0)] private Move _Move;        //  4 = 32 bits
-        [FieldOffset( 4)] private short _Score;      //  2 = 16 bits
-        [FieldOffset( 6)] private short _StatEval;   //  2 = 16 bits
-        [FieldOffset( 8)] private ushort _Key;       //  2 = 16 bits
-        [FieldOffset(10)] private byte _AgePVType;   //  1 =  8 bits (5 bits for age, 1 for isPV, 2 for type)
-        [FieldOffset(11)] private byte _Depth;       //  1 =  8 bits
+        [FieldOffset(0)] private Move _Move;        //  4 = 32 bits
+        [FieldOffset(2)] private short _Score;      //  2 = 16 bits
+        [FieldOffset(4)] private short _StatEval;   //  2 = 16 bits
+        [FieldOffset(6)] private ushort _Key;       //  2 = 16 bits
+        [FieldOffset(8)] private byte _AgePVType;   //  1 =  8 bits (5 bits for age, 1 for isPV, 2 for type)
+        [FieldOffset(9)] private byte _Depth;       //  1 =  8 bits
 
 
         public readonly short Score => _Score;

--- a/Logic/Transposition/TranspositionTable.cs
+++ b/Logic/Transposition/TranspositionTable.cs
@@ -14,7 +14,7 @@ namespace Peeper.Logic.Transposition
 
         private const int MinTTClusters = 1000;
 
-        public const int EntriesPerCluster = 1;
+        public const int EntriesPerCluster = 3;
 
         private TTCluster* Clusters;
         public ulong ClusterCount { get; private set; }


### PR DESCRIPTION
```
Elo   | 9.68 +- 6.79 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 9264 W: 4513 L: 4255 D: 496
Penta | [963, 191, 2159, 263, 1056]
```
https://somelizard.pythonanywhere.com/test/2376/