### PR TITLE
Null move pruning

### DIFF
--- a/Logic/Core/Position.cs
+++ b/Logic/Core/Position.cs
@@ -233,6 +233,32 @@ namespace Peeper.Logic.Core
         }
 
 
+        public void MakeNullMove()
+        {
+            Unsafe.CopyBlock(NextState, State, BoardState.StateCopySize);
+
+            if (UpdateNN)
+            {
+                NNUE.MakeNullMove(this);
+            }
+
+            State++;
+            MoveNumber++;
+            ToMove = Not(ToMove);
+            State->Hash.ZobristChangeToMove();
+
+            UpdateState();
+        }
+
+
+        public void UnmakeNullMove()
+        {
+            State--;
+            MoveNumber--;
+            ToMove = Not(ToMove);
+        }
+
+
         [MethodImpl(Inline)]
         private void UpdateHash(int color, int type, int sq)
         {

--- a/Logic/Data/Move.cs
+++ b/Logic/Data/Move.cs
@@ -62,5 +62,7 @@ namespace Peeper.Logic.Data
 
         public static bool operator ==(Move left, ScoredMove right) => left.Equals(right);
         public static bool operator !=(Move left, ScoredMove right) => !left.Equals(right);
+
+        public static implicit operator bool(Move m) => !m.IsNull();
     }
 }

--- a/Logic/Search/SearchOptions.cs
+++ b/Logic/Search/SearchOptions.cs
@@ -13,9 +13,16 @@ namespace Peeper.Logic.Search
 
         public static bool CuteChessWorkaround = false;
 
+        public const bool UseRFP = true;
+        public const bool UseNMP = true;
+
         public static int AspWindow = 0;
 
         public static int RFPMult = 100;
         public static int RFPDepth = 5;
+
+        public static int NMPDepth = 5;
+        public static int NMPBaseRed = 3;
+        public static int NMPDepthDiv = 4;
     }
 }

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -112,7 +112,8 @@ namespace Peeper.Logic.Search
 
             eval = ss->StaticEval = NNUE.GetEvaluation(pos);
 
-            if (depth <= RFPDepth
+            if (UseRFP
+                && depth <= RFPDepth
 #if TODO
                 && ttMove.IsNull()
                 && !IsWin(eval)
@@ -121,6 +122,26 @@ namespace Peeper.Logic.Search
                 && eval - RFPMargin(depth) >= beta)
             {
                 return eval;
+            }
+
+            if (UseNMP
+                && depth >= NMPDepth
+                && ss->StaticEval >= beta
+                && (ss - 1)->CurrentMove)
+            {
+                int reduction = NMPBaseRed + (depth / NMPDepthDiv);
+                ss->CurrentMove = Move.Null;
+                ss->ContinuationHistory = history.Continuations[0][0][0];
+
+                pos.MakeNullMove();
+                score = -Negamax<NonPVNode>(pos, ss + 1, -beta, -beta + 1, depth - reduction);
+                pos.UnmakeNullMove();
+
+                if (score >= beta)
+                {
+                    return IsWin(score) ? beta : score;
+                }
+
             }
 
 

--- a/Logic/USI/USIClient.cs
+++ b/Logic/USI/USIClient.cs
@@ -272,6 +272,9 @@ namespace Peeper.Logic.USI
             Options[nameof(RFPDepth)].SetMinMax(1, 10);
             Options[nameof(RFPMult)].SetMinMax(50, 140);
 
+            Options[nameof(NMPDepth)].AutoMinMax();
+            Options[nameof(NMPBaseRed)].AutoMinMax();
+            Options[nameof(NMPDepthDiv)].AutoMinMax();
 
             foreach (var optName in Options.Keys)
             {

--- a/Logic/Util/SearchBench.cs
+++ b/Logic/Util/SearchBench.cs
@@ -5,7 +5,7 @@ namespace Peeper.Logic.Util
 {
     public static class SearchBench
     {
-        public const int DefaultDepth = 8;
+        public const int DefaultDepth = 9;
 
         public static void Go(int depth = DefaultDepth, bool openBench = false)
         {


### PR DESCRIPTION
```
Elo   | 28.68 +- 12.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2574 W: 1353 L: 1141 D: 80
Penta | [232, 41, 638, 35, 341]
```
https://somelizard.pythonanywhere.com/test/2402/