### PR TITLE
Razoring

### DIFF
--- a/Logic/Search/SearchOptions.cs
+++ b/Logic/Search/SearchOptions.cs
@@ -15,6 +15,7 @@ namespace Peeper.Logic.Search
 
         public const bool UseRFP = true;
         public const bool UseNMP = true;
+        public const bool UseRazoring = true;
 
         public static int AspWindow = 0;
 
@@ -24,5 +25,8 @@ namespace Peeper.Logic.Search
         public static int NMPDepth = 5;
         public static int NMPBaseRed = 3;
         public static int NMPDepthDiv = 4;
+
+        public static int RazoringMaxDepth = 4;
+        public static int RazoringMult = 280;
     }
 }

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -112,6 +112,7 @@ namespace Peeper.Logic.Search
 
             eval = ss->StaticEval = NNUE.GetEvaluation(pos);
 
+
             if (UseRFP
                 && depth <= RFPDepth
 #if TODO
@@ -123,6 +124,19 @@ namespace Peeper.Logic.Search
             {
                 return eval;
             }
+
+
+            if (UseRazoring
+                && !isPV
+                && depth <= RazoringMaxDepth
+                && alpha < 2000
+                && ss->StaticEval + RazoringMult * depth <= alpha)
+            {
+                score = QSearch<NodeType>(pos, ss, alpha, alpha + 1);
+                if (score <= alpha)
+                    return score;
+            }
+
 
             if (UseNMP
                 && depth >= NMPDepth
@@ -141,11 +155,10 @@ namespace Peeper.Logic.Search
                 {
                     return IsWin(score) ? beta : score;
                 }
-
             }
 
 
-        MovesLoop:
+            MovesLoop:
 
             int legalMoves = 0;
             int playedMoves = 0;
@@ -445,7 +458,7 @@ namespace Peeper.Logic.Search
 
                 score = -QSearch<NodeType>(pos, ss + 1, -beta, -alpha);
 
-            SkipSearch:
+                SkipSearch:
 
                 pos.UnmakeMove(m);
 

--- a/Logic/USI/USIClient.cs
+++ b/Logic/USI/USIClient.cs
@@ -272,7 +272,10 @@ namespace Peeper.Logic.USI
             Options[nameof(RFPDepth)].SetMinMax(1, 10);
             Options[nameof(RFPMult)].SetMinMax(50, 140);
 
-            Options[nameof(NMPDepth)].AutoMinMax();
+            Options[nameof(RazoringMaxDepth)].SetMinMax(1, 10);
+            Options[nameof(RazoringMult)].AutoMinMax();
+
+            Options[nameof(NMPDepth)].SetMinMax(1, 10);
             Options[nameof(NMPBaseRed)].AutoMinMax();
             Options[nameof(NMPDepthDiv)].AutoMinMax();
 


### PR DESCRIPTION
```
Elo   | 11.17 +- 7.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7622 W: 3820 L: 3575 D: 227
Penta | [784, 102, 1915, 105, 905]
```
https://somelizard.pythonanywhere.com/test/2404/