### PR TITLE
Reduce non-PV nodes

### DIFF
--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -215,6 +215,8 @@ namespace Peeper.Logic.Search
 
                 if (depth >= 2 && legalMoves >= 6)
                 {
+                    R += (!isPV).AsInt();
+
                     //  At least reduce by 1, but never enough to drop into qsearch
                     int reducedDepth = Math.Min(Math.Max(1, newDepth - R), newDepth - 1);
 
@@ -237,15 +239,12 @@ namespace Peeper.Logic.Search
                 }
 
 
-            SkipSearch:
+                SkipSearch:
 
                 pos.UnmakeMove(m);
 
                 if (isRoot)
-                {
-                    //  Update the NodeTM table with the number of nodes that were searched in this subtree.
                     thisThread.NodeTable[moveFrom][moveTo] += thisThread.Nodes - prevNodes;
-                }
 
                 if (thisThread.ShouldStop())
                     return ScoreDraw;

--- a/Logic/Util/Utilities.cs
+++ b/Logic/Util/Utilities.cs
@@ -96,6 +96,11 @@ namespace Peeper.Logic.Util
         public static ulong Upper(this Bitmask b) => (ulong)(b >> 64);
         public static ulong Lower(this Bitmask b) => (ulong)b;
 
+
+        [MethodImpl(Inline)]
+        public static int AsInt(this bool b) => b ? 1 : 0;
+
+
         [MethodImpl(Inline)]
         public static Bitmask Shift(this Bitmask b, int dir)
         {


### PR DESCRIPTION
```
Elo   | 24.63 +- 12.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3236 W: 1688 L: 1459 D: 89
Penta | [352, 39, 720, 42, 465]
```
https://somelizard.pythonanywhere.com/test/2408/