### PR TITLE
Fixed rare IsLegal bug with drops

### DIFF
--- a/Logic/Core/Position.cs
+++ b/Logic/Core/Position.cs
@@ -361,12 +361,11 @@ namespace Peeper.Logic.Core
                 }
 
                 int checker = LSB(State->Checkers);
-                if ((Line(ourKing, checker) & SquareBB(moveTo)) != 0)
+                if (Line(ourKing, checker).HasBit(moveTo))
                 {
                     //  This move is another piece which has moved into the LineBB between our king and the checking piece.
-                    //  This will be legal as long as it isn't pinned.
-
-                    return pinnedPieces == 0 || (pinnedPieces & SquareBB(moveFrom)) == 0;
+                    //  This will be legal if it's a drop, or if the piece being moved isn't pinned.
+                    return move.IsDrop || !pinnedPieces.HasBit(moveFrom);
                 }
 
                 //  This isn't a king move and doesn't get us out of check, so it's illegal.
@@ -379,7 +378,10 @@ namespace Peeper.Logic.Core
                 return ((bb.AttackersTo(moveTo, bb.Occupancy ^ SquareBB(ourKing)) & bb.Colors[theirColor]) | (KingMoveMask(moveTo) & SquareBB(theirKing))) == 0;
             }
         
-            return (!State->BlockingPieces[ourColor].HasBit(moveFrom) || Ray(moveFrom, moveTo).HasBit(ourKing));
+            //  Good if it's a drop anywhere,
+            //  or if the piece being moved isn't a blocker
+            //  or the piece is a blocker, but it's staying between the king and checker
+            return move.IsDrop || !State->BlockingPieces[ourColor].HasBit(moveFrom) || Ray(moveFrom, moveTo).HasBit(ourKing);
         }
 
 
@@ -663,6 +665,7 @@ namespace Peeper.Logic.Core
             sb.AppendLine(bb.ToString());
 
             sb.AppendLine($"\r\nFEN: {ActiveFormatter.FormatSFen(this)}");
+            sb.AppendLine($"FEN: {InactiveFormatter.FormatSFen(this)}");
             sb.AppendLine($"\r\nBlack hand: {State->Hands[Black].ToString(Black)}");
             sb.AppendLine($"White hand: {State->Hands[White].ToString(White)}");
             sb.AppendLine($"\r\n{ColorToString(ToMove)} to move");

--- a/Logic/Data/MoveList.cs
+++ b/Logic/Data/MoveList.cs
@@ -51,10 +51,11 @@ namespace Peeper.Logic.Data
             StringBuilder sb = new StringBuilder();
 
             sb.AppendLine($"Total of {Size}");
+            var mArr = ToSpan().ToArray();
 
             for (int type = 0; type < PieceNB; type++)
             {
-                int n = ToSpan().ToArray().Count(x => !x.Move.IsDrop && bb.GetPieceAtIndex(x.Move.From) == type);
+                int n = mArr.Count(x => !x.Move.IsDrop && bb.GetPieceAtIndex(x.Move.From) == type);
                 if (n == 0)
                     continue;
 
@@ -74,18 +75,29 @@ namespace Peeper.Logic.Data
                 sb.AppendLine();
             }
 
-            int drops = ToSpan().ToArray().Count(x => x.Move.IsDrop);
+            int drops = mArr.Count(x => x.Move.IsDrop);
             if (drops != 0)
             {
                 sb.AppendLine($"Drops == {drops}");
 
-                for (int i = 0; i < Size; i++)
+                foreach (var type in DroppableTypes)
                 {
-                    Move m = Buffer[i].Move;
-                    if (!m.IsDrop)
+                    int n = mArr.Count(x => x.Move.IsDrop && x.Move.DroppedPiece == type);
+                    if (n == 0)
                         continue;
 
-                    sb.Append($"{m} ");
+                    sb.Append($"{PieceToString(type)}\t{n} -> ");
+
+                    for (int i = 0; i < Size; i++)
+                    {
+                        Move m = Buffer[i].Move;
+                        if (!m.IsDrop || m.DroppedPiece != type)
+                            continue;
+
+                        sb.Append($"{m} ");
+                    }
+
+                    sb.AppendLine();
                 }
             }
 

--- a/Logic/Protocols/IFormat.cs
+++ b/Logic/Protocols/IFormat.cs
@@ -10,6 +10,7 @@ namespace Peeper.Logic.Protocols
         public static readonly IFormat UCIFormatter = new UCIFormat();
 
         public static IFormat ActiveFormatter = USIFormatter;
+        public static IFormat InactiveFormatter => (ActiveFormatter == USIFormatter) ? UCIFormatter : USIFormatter;
         public static bool IsFormatterUSI { get; private set; } = true;
 
         public static void SetUSIFormatter()

--- a/Logic/Util/PerftData.cs
+++ b/Logic/Util/PerftData.cs
@@ -10,8 +10,9 @@ namespace Peeper.Logic.Util
         {
             {"l6nl/5+P1gk/2np1S3/p1p4Pp/3P2Sp1/1PPb2P1P/P5GS1/R8/LN4bKL w GR5pnsg 1", new ulong[] { 1, 207, 28684, 4809015, 516925165 } },
             {"lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1", new ulong[] { 1, 30, 900, 25470, 719731, 19861490, 547581517, 15086269607 } },
-            {"9/9/9/3k5/9/5K3/9/9/9 b RB2G2S2N2L9Prb2g2s2n2l9p 1", new ulong[] { 1, 524, 248257, 112911856, 50852853772 } },
+            {"l7l/3s5/prnp2kp1/2p1Gppnp/1P7/PnPP1P3/3BP2PP/1S1G5/LN1K1G1+rL b SBG3ps 91", new ulong[] { 1, 180, 15217, 2067680, 129175973, 13896719538 } },
             {"8l/1l+R2P3/p2pBG1pp/kps1p4/Nn1P2G2/P1P1P2PP/1PS6/1KSG3+r1/LN2+p3L w Sbgn3p 124", new ulong[] { 1, 178, 18041, 2552846, 207741677, 24120401335 } },
+            {"9/9/9/3k5/9/5K3/9/9/9 b RB2G2S2N2L9Prb2g2s2n2l9p 1", new ulong[] { 1, 524, 248257, 112911856, 50852853772 } },
         };
     }
 }

--- a/Logic/Util/Utilities.cs
+++ b/Logic/Util/Utilities.cs
@@ -427,7 +427,9 @@ namespace Peeper.Logic.Util
                         pos.GeneratePseudoLegal(ref pseudoList);
 
                         StringBuilder sb = new();
-                        sb.Append($"{sfen}\tMove {m} wasn't found!");
+                        sb.AppendLine($"Move {m} wasn't found! at {i} / {moves.Length}");
+                        sb.AppendLine($"cmd: {cmd}");
+                        sb.AppendLine($"CurrentFEN: {sfen}");
                         sb.AppendLine($"StartFEN: {setup.StartFEN}");
                         sb.AppendLine($"legal: [{Stringify(legalList.ToSpan())}]/[{StringifyFlipFormat(legalList.ToSpan())}]");
                         sb.AppendLine($"pseudo: [{Stringify(pseudoList.ToSpan())}]/[{StringifyFlipFormat(pseudoList.ToSpan())}]");

--- a/Logic/Util/Utilities.cs
+++ b/Logic/Util/Utilities.cs
@@ -409,7 +409,33 @@ namespace Peeper.Logic.Util
             for (int i = 0; i < moves.Length; i++)
             {
                 if (pos.TryFindMove(moves[i], out Move m))
+                {
                     pos.MakeMove(m);
+                }
+                else
+                {
+                    if (USIClient.Active)
+                    {
+                        var sfen = pos.GetSFen();
+                        var cmd = string.Join(" ", input);
+
+                        MoveList legalList = new();
+                        pos.GenerateLegal(ref legalList);
+                        var legal = string.Join(", ", legalList.ToSpan().ToArray().Select(x => x.Move));
+
+                        MoveList pseudoList = new();
+                        pos.GeneratePseudoLegal(ref pseudoList);
+
+                        StringBuilder sb = new();
+                        sb.Append($"{sfen}\tMove {m} wasn't found!");
+                        sb.AppendLine($"StartFEN: {setup.StartFEN}");
+                        sb.AppendLine($"legal: [{Stringify(legalList.ToSpan())}]/[{StringifyFlipFormat(legalList.ToSpan())}]");
+                        sb.AppendLine($"pseudo: [{Stringify(pseudoList.ToSpan())}]/[{StringifyFlipFormat(pseudoList.ToSpan())}]");
+
+                        FailFast(sb.ToString());
+                    }
+                }
+                    
 
                 setup.SetupMoves.Add(m);
             }


### PR DESCRIPTION
IsLegal handled drops incorrectly when a piece was pinned on a square whose numerical value was the same as the type of piece being dropped, causing drops for that type of piece to only be legal if they were on the same rank as the king.