### PR TITLE
Use improving in RFP

### DIFF
--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -51,6 +51,8 @@ namespace Peeper.Logic.Search
             short eval = ss->StaticEval;
             int startingAlpha = alpha;
 
+            bool improving = false;
+
             if (isPV)
                 thisThread.SelDepth = Math.Max(thisThread.SelDepth, ss->Ply + 1);
 
@@ -112,6 +114,13 @@ namespace Peeper.Logic.Search
 
             eval = ss->StaticEval = NNUE.GetEvaluation(pos);
 
+            if (ss->Ply >= 2)
+            {
+                improving = (ss - 2)->StaticEval != ScoreNone ? ss->StaticEval > (ss - 2)->StaticEval
+                          : (ss - 4)->StaticEval != ScoreNone ? ss->StaticEval > (ss - 4)->StaticEval
+                          :                                     true;
+            }
+
 
             if (UseRFP
                 && depth <= RFPDepth
@@ -120,7 +129,7 @@ namespace Peeper.Logic.Search
                 && !IsWin(eval)
                 && eval >= beta
 #endif
-                && eval - RFPMargin(depth) >= beta)
+                && eval - RFPMargin(depth, improving) >= beta)
             {
                 return eval;
             }
@@ -670,7 +679,7 @@ namespace Peeper.Logic.Search
         }
 
 
-        private static int RFPMargin(int depth) => depth * RFPMult;
+        private static int RFPMargin(int depth, bool improving) => (depth - (improving ? 1 : 0)) * RFPMult;
 
         private static int StatBonus(int depth) => depth * StatBonusMult;
 


### PR DESCRIPTION
```
Elo   | 32.95 +- 14.18 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2348 W: 1260 L: 1038 D: 50
Penta | [236, 20, 548, 26, 344]
```
http://somelizard.pythonanywhere.com/test/2451/